### PR TITLE
Add EventCategoryMouseButton to MouseButtonEvent

### DIFF
--- a/Hazel/src/Hazel/Events/MouseEvent.h
+++ b/Hazel/src/Hazel/Events/MouseEvent.h
@@ -54,7 +54,7 @@ namespace Hazel {
 	public:
 		MouseCode GetMouseButton() const { return m_Button; }
 
-		EVENT_CLASS_CATEGORY(EventCategoryMouse | EventCategoryInput)
+		EVENT_CLASS_CATEGORY(EventCategoryMouse | EventCategoryInput | EventCategoryMouseButton)
 	protected:
 		MouseButtonEvent(const MouseCode button)
 			: m_Button(button) {}


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
At the moment `EventCategoryMouseButton` is not used anywhere. 
We should either remove it or make it part of MouseButtonEvent
